### PR TITLE
Upscaling fix in bethe_heitler.F90

### DIFF
--- a/epoch3d/src/physics_packages/bethe_heitler.F90
+++ b/epoch3d/src/physics_packages/bethe_heitler.F90
@@ -334,7 +334,7 @@ CONTAINS
           photon)
       CALL destroy_particle(photon)
     ELSE 
-      photon%optical_depth_bremsstrahlung = -LOG(random())
+      photon%optical_depth_bremsstrahlung = photon%optical_depth_bremsstrahlung -LOG(random())
     END IF
 
   END SUBROUTINE generate_pair


### PR DESCRIPTION
This updates the optical depth by adding on the new random depth rather than setting it to this new number. This makes the algorithm more resilient at high upscaling values by retaining some kind of 'time history' in the particle splitting.

The plot attached shows why this is necessary with the 'naive' version of resetting the optical depth leading to a factor of 2 reduction in the positron production rate.

![upscaling_motivation](https://github.com/user-attachments/assets/8aae80b0-36f3-4087-b784-da01723af22b)
