### PR TITLE
Use ubuntu-latest for CI

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -49,14 +49,10 @@ jobs:
 
     steps:
     - name: Install dependencies
-      run: sudo apt update &&
-           sudo apt install -y
-               python3-dev
-               python3-numpy
-               python3-nose
-               python3-matplotlib
-               libpython3-dev
-               mpich
+      run: |
+        sudo apt update &&
+        sudo apt install -y python3-dev python3-numpy python3-nose python3-matplotlib libpython3-dev mpich
+        pip install sdfr
 
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event_name != 'pull_request_review' ||
         contains(github.event.pull_request.labels.*.name, 'auto-pr')
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update &&
-        sudo apt install -y python3-dev python3-numpy python3-nose python3-matplotlib libpython3-dev mpich
+        sudo apt install -y python3-dev python3-numpy python3-nose python3-matplotlib libpython3-dev openmpi-bin libopenmpi-dev
         pip install sdfr
 
     - name: Checkout code

--- a/epoch1d/tests/test_custom_stencils.py
+++ b/epoch1d/tests/test_custom_stencils.py
@@ -23,7 +23,7 @@ import platform
 import numpy as np
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-import sdf
+import sdfr
 
 from . import SimTest
 
@@ -86,7 +86,7 @@ class test_custom_stencils(SimTest):
             l = dumps.setdefault(solver, [])
             for dump in [osp.join(solver, '{:04d}.sdf'.format(i))
                          for i in range(8)]:
-                l.append(sdf.read(dump, dict=True))
+                l.append(sdfr.read(dump, dict=True))
 
     def test_createplot(self):
         if platform.system() == 'Darwin':

--- a/epoch1d/tests/test_landau.py
+++ b/epoch1d/tests/test_landau.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import sdf
+import sdfr
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import unittest
@@ -25,20 +25,20 @@ from . import SimTest
 
 
 def showdatafields(sdffile):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     print('Data fields present in "' + sdffile + '":')
     print(data.keys())
 
 
 def plotdump(sdffile, key, ax):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     array = data[key].data
     ax.plot(array)
     ax.set_title(r'{:2.1f} ms'.format(data['Header']['time']*1e3))
 
 
 def plotdump2d(sdffile, key, ax):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     if len(data[key].dims) == 3:
         array = data[key].data[:, :, 0]
     else:

--- a/epoch1d/tests/test_laser.py
+++ b/epoch1d/tests/test_laser.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import sdf
+import sdfr
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import unittest
@@ -25,13 +25,13 @@ from tests import SimTest
 
 
 def showdatafields(sdffile):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     print('Data fields present in "' + sdffile + '":')
     print(data.keys())
 
 
 def plotdump(sdffile, key, ax):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     array = data[key].data
     ax.plot(array)
     ax.set_title('{:2.1f} fs'.format(data['Header']['time']*1e15))
@@ -57,7 +57,7 @@ def createplots():
 class test_laser(SimTest):
 
     def totaleyassert(self, dump, val):
-        data = sdf.read(dump, dict=True)
+        data = sdfr.read(dump, dict=True)
         ey = data['Electric Field/Ey'].data**2
         eysum = np.sum(ey)
         test = np.isclose(eysum, val)

--- a/epoch1d/tests/test_maxwell_solvers.py
+++ b/epoch1d/tests/test_maxwell_solvers.py
@@ -23,7 +23,7 @@ import platform
 import numpy as np
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-import sdf
+import sdfr
 
 from . import SimTest
 
@@ -81,7 +81,7 @@ class test_maxwell_solvers(SimTest):
             l = dumps.setdefault(solver, [])
             for dump in [osp.join(solver, '{:04d}.sdf'.format(i))
                          for i in range(8)]:
-                l.append(sdf.read(dump, dict=True))
+                l.append(sdfr.read(dump, dict=True))
 
     def test_createplot(self):
         if platform.system() == 'Darwin':

--- a/epoch1d/tests/test_twostream.py
+++ b/epoch1d/tests/test_twostream.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import sdf
+import sdfr
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import unittest
@@ -25,20 +25,20 @@ from . import SimTest
 
 
 def showdatafields(sdffile):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     print('Data fields present in "' + sdffile + '":')
     print(data.keys())
 
 
 def plotdump(sdffile, key, ax):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     array = data[key].data
     ax.plot(array)
     ax.set_title(r'{:2.1f} ms'.format(data['Header']['time']*1e3))
 
 
 def plotdump2d(sdffile, key, ax):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     if len(data[key].dims) == 3:
         array = data[key].data[:, :, 0]
     else:

--- a/epoch2d/tests/test_custom_stencils.py
+++ b/epoch2d/tests/test_custom_stencils.py
@@ -23,7 +23,7 @@ import platform
 import numpy as np
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-import sdf
+import sdfr
 
 from . import SimTest
 
@@ -110,7 +110,7 @@ class test_custom_stencils(SimTest):
             l = dumps.setdefault(solver, [])
             for dump in [osp.join(solver, '{:04d}.sdf'.format(i))
                          for i in range(4)]:
-                l.append(sdf.read(dump, dict=True))
+                l.append(sdfr.read(dump, dict=True))
 
     def test_createplot(self):
         if platform.system() == 'Darwin':

--- a/epoch2d/tests/test_custom_stencils.py
+++ b/epoch2d/tests/test_custom_stencils.py
@@ -130,8 +130,8 @@ class test_custom_stencils(SimTest):
                                                 min(yaxis), max(yaxis)])
                 im.set_clim([-1e11, 1e11])
                 t = dump['Header']['time']
-                dx = np.asscalar(dump[key].grid_mid.data[0][1]
-                                 - dump[key].grid_mid.data[0][0])
+                dx = (dump[key].grid_mid.data[0][1]
+                      - dump[key].grid_mid.data[0][0]).item()
 
                 vg_yee = c*np.cos(k_l*dx/2.0) \
                     / np.sqrt(1-(c*dt[solver]/dx*np.sin(k_l*dx/2.0))**2)

--- a/epoch2d/tests/test_laser.py
+++ b/epoch2d/tests/test_laser.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import sdf
+import sdfr
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import unittest
@@ -25,13 +25,13 @@ from . import SimTest
 
 
 def showdatafields(sdffile):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     print('Data fields present in "' + sdffile + '":')
     print(data.keys())
 
 
 def plotdump(sdffile, key, ax):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     array = data[key].data
     ax.imshow(array.T, origin='lower')
     ax.set_title('{:2.1f} fs'.format(data['Header']['time']*1e15))
@@ -57,7 +57,7 @@ def createplots():
 class test_laser(SimTest):
 
     def totaleyassert(self, dump, val):
-        data = sdf.read(dump, dict=True)
+        data = sdfr.read(dump, dict=True)
         ey = data['Electric Field/Ey'].data**2
         eysum = np.sum(ey)
         test = np.isclose(eysum, val)

--- a/epoch2d/tests/test_maxwell_solvers.py
+++ b/epoch2d/tests/test_maxwell_solvers.py
@@ -23,7 +23,7 @@ import platform
 import numpy as np
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-import sdf
+import sdfr
 
 from . import SimTest
 
@@ -89,7 +89,7 @@ class test_maxwell_solvers(SimTest):
             l = dumps.setdefault(solver, [])
             for dump in [osp.join(solver, '{:04d}.sdf'.format(i))
                          for i in range(4)]:
-                l.append(sdf.read(dump, dict=True))
+                l.append(sdfr.read(dump, dict=True))
 
     def test_createplot(self):
         if platform.system() == 'Darwin':

--- a/epoch3d/tests/test_custom_stencils.py
+++ b/epoch3d/tests/test_custom_stencils.py
@@ -23,7 +23,7 @@ import platform
 import numpy as np
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-import sdf
+import sdfr
 
 from . import SimTest
 
@@ -122,7 +122,7 @@ class test_custom_stencils(SimTest):
             l = dumps.setdefault(solver, [])
             for dump in [osp.join(solver, '{:04d}.sdf'.format(i))
                          for i in range(4)]:
-                l.append(sdf.read(dump, dict=True))
+                l.append(sdfr.read(dump, dict=True))
 
     def test_createplot(self):
         if platform.system() == 'Darwin':

--- a/epoch3d/tests/test_custom_stencils.py
+++ b/epoch3d/tests/test_custom_stencils.py
@@ -142,8 +142,8 @@ class test_custom_stencils(SimTest):
                                                 min(yaxis), max(yaxis)])
                 im.set_clim([-1e11, 1e11])
                 t = dump['Header']['time']
-                dx = np.asscalar(dump[key].grid_mid.data[0][1]
-                                 - dump[key].grid_mid.data[0][0])
+                dx = (dump[key].grid_mid.data[0][1]
+                      - dump[key].grid_mid.data[0][0]).item()
 
                 vg_yee = c*np.cos(k_l*dx/2.0) \
                     / np.sqrt(1-(c*dt[solver]/dx*np.sin(k_l*dx/2.0))**2)

--- a/epoch3d/tests/test_laser.py
+++ b/epoch3d/tests/test_laser.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-import sdf
+import sdfr
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import unittest
@@ -25,13 +25,13 @@ from . import SimTest
 
 
 def showdatafields(sdffile):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     print('Data fields present in "' + sdffile + '":')
     print(data.keys())
 
 
 def plotdump(sdffile, key, ax):
-    data = sdf.read(sdffile, dict=True)
+    data = sdfr.read(sdffile, dict=True)
     array = data[key].data[:, 80, :]
     ax.imshow(array.T, origin='lower')
     ax.set_title('{:2.1f} fs'.format(data['Header']['time']*1e15))
@@ -57,7 +57,7 @@ def createplots():
 class test_laser(SimTest):
 
     def totaleyassert(self, dump, val):
-        data = sdf.read(dump, dict=True)
+        data = sdfr.read(dump, dict=True)
         ey = data['Electric Field/Ex'].data**2
         eysum = np.sum(ey)
         test = np.isclose(eysum, val)

--- a/epoch3d/tests/test_maxwell_solvers.py
+++ b/epoch3d/tests/test_maxwell_solvers.py
@@ -23,7 +23,7 @@ import platform
 import numpy as np
 import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-import sdf
+import sdfr
 
 from . import SimTest
 
@@ -98,7 +98,7 @@ class test_maxwell_solvers(SimTest):
             l = dumps.setdefault(solver, [])
             for dump in [osp.join(solver, '{:04d}.sdf'.format(i))
                          for i in range(4)]:
-                l.append(sdf.read(dump, dict=True))
+                l.append(sdfr.read(dump, dict=True))
 
     def test_createplot(self):
         if platform.system() == 'Darwin':

--- a/scripts/run-tests-epoch-all.sh
+++ b/scripts/run-tests-epoch-all.sh
@@ -45,14 +45,7 @@ cd ..
 PYTHONCMD=$(which python3)
 if [ "$PYTHONCMD"x = x ]; then
   PYTHONCMD=$(which python)
-  FLG=""
-else
-  FLG="-3"
 fi
-
-# Build SDF/C and install python sdf reader
-(cd SDF/C; make)
-SDF/utilities/build.sh $FLG
 
 # show system info
 scripts/system_info.sh

--- a/scripts/system_info.sh
+++ b/scripts/system_info.sh
@@ -40,6 +40,6 @@ echo -n 'numpy version: '
 $PYTHONCMD -c 'import numpy; print(numpy.__version__)'
 echo -n 'matplotlib version: '
 $PYTHONCMD -c 'import matplotlib; print(matplotlib.__version__)'
-echo -n 'sdf version: '
-$PYTHONCMD -c 'import sdf; print(sdf.__version__)'
+echo -n 'sdfr version: '
+$PYTHONCMD -c 'import sdfr; print(sdfr.__version__)'
 


### PR DESCRIPTION
Replace the deprecated (and removed) ubuntu-20.04 with ubuntu-latest.

Additional changes:

- No longer build sdf reader.
- Install and use sdfr package in tests.
- Switch to open-mpi, MPICH appears broken.
- Replace deprecated (and removed) numpy method.